### PR TITLE
fix laggy event bug; expose window struct members

### DIFF
--- a/src/concurrent_window_sdl2.rs
+++ b/src/concurrent_window_sdl2.rs
@@ -17,11 +17,12 @@ use game_window_sdl2::sdl2_map_mouse;
 
 /// A widow implemented by SDL2 back-end.
 pub struct RenderWindowSDL2 {
-    window: sdl2::video::Window,
-    // Allow dead code because this keeps track of the OpenGL context.
-    // Will be released on drop.
-    #[allow(dead_code)]
-    context: sdl2::video::GLContext,
+  /// SDL window handle
+  pub window: sdl2::video::Window,
+  /// Allow dead code because this keeps track of the OpenGL context.
+  /// Will be released on drop.
+  #[allow(dead_code)]
+  pub context: sdl2::video::GLContext,
 }
 
 impl RenderWindow for RenderWindowSDL2 {

--- a/src/game_window_sdl2.rs
+++ b/src/game_window_sdl2.rs
@@ -18,11 +18,12 @@ use concurrent_window_sdl2::{
     ConcurrentWindowSDL2,
 };
 
-
 /// A widow implemented by SDL2 back-end.
 pub struct GameWindowSDL2 {
-    concurrent_window: ConcurrentWindowSDL2,
-    render_window: RenderWindowSDL2,
+  /// concurrent window used for events
+  pub concurrent_window: ConcurrentWindowSDL2,
+  /// window used for rendering
+  pub render_window: RenderWindowSDL2,
 }
 
 impl GameWindowSDL2 {


### PR DESCRIPTION
I think the window members need to be exposed so that we can do things like

```
fn mouse_move(&mut self, w: &mut GameWindowSDL2, args: &MouseMoveArgs) {
  mouse::warp_mouse_in_window(
    &w.render_window.window,
    WINDOW_WIDTH as i32 / 2,
    WINDOW_HEIGHT as i32 / 2
  );
}
```
