### PR TITLE
Removed dependency to shader_version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,10 +23,6 @@ git = "https://github.com/AngryLawyer/rust-sdl2"
 
 git = "https://github.com/PistonDevelopers/piston"
 
-[dependencies.shader_version]
-
-git = "https://github.com/pistondevelopers/shader_version"
-
 [dependencies.gl]
 
 git = "https://github.com/bjz/gl-rs"


### PR DESCRIPTION
This is reexported under Piston.
