### PR TITLE
Add Window.get_size implementation to WindowSDL2

### DIFF
--- a/src/window_sdl2.rs
+++ b/src/window_sdl2.rs
@@ -99,6 +99,11 @@ impl Window for WindowSDL2 {
         (w as u32, h as u32)
     }
 
+    fn get_size(&self) -> (u32, u32) {
+        let (w, h) = self.window.get_size();
+        (w as u32, h as u32)
+    }
+
     fn close(&mut self) {
         self.should_close = true;
     }


### PR DESCRIPTION
Depending a default trait implementation was insufficient as the trait used the size the window was constructed with, which is wrong if the window has ever changed size.
