### PR TITLE
`quack::Me` got removed.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ use window::{
 };
 use input::{ keyboard, Button, MouseButton, Input, Motion };
 use shader_version::opengl::OpenGL;
-use quack::{ ActOn, Action, GetFrom, SetAt, Set, Me };
+use quack::{ ActOn, Action, GetFrom, SetAt, Set };
 
 /// A widow implemented by SDL2 back-end.
 pub struct Sdl2Window {
@@ -104,7 +104,8 @@ impl GetFrom for (ShouldClose, Sdl2Window) {
     type Property = ShouldClose;
     type Object = Sdl2Window;
 
-    fn get_from(_: Me<Self>, obj: &Sdl2Window) -> ShouldClose {
+    // fn get_from(_: Me<Self>, obj: &Sdl2Window) -> ShouldClose {
+    fn get_from(obj: &Sdl2Window) -> ShouldClose {
         ShouldClose(obj.should_close)
     }
 }
@@ -113,7 +114,7 @@ impl GetFrom for (Size, Sdl2Window) {
     type Property = Size;
     type Object = Sdl2Window;
 
-    fn get_from(_: Me<Self>, obj: &Sdl2Window) -> Size {
+    fn get_from(obj: &Sdl2Window) -> Size {
         let (w, h) = obj.window.get_size();
         Size([w as u32, h as u32])
     }
@@ -123,7 +124,7 @@ impl ActOn<()> for (SwapBuffers, Sdl2Window) {
     type Action = SwapBuffers;
     type Object = Sdl2Window;
 
-    fn act_on(_: Me<Self>, _: SwapBuffers, window: &mut Sdl2Window) {
+    fn act_on(_: SwapBuffers, window: &mut Sdl2Window) {
         window.window.gl_swap_window();
     }
 }
@@ -133,7 +134,6 @@ impl ActOn<Option<Input>> for (PollEvent, Sdl2Window) {
     type Object = Sdl2Window;
 
     fn act_on(
-        _: Me<Self>, 
         _: PollEvent, 
         window: &mut Sdl2Window
     ) -> Option<Input> {
@@ -205,7 +205,6 @@ impl SetAt for (CaptureCursor, Sdl2Window) {
     type Object = Sdl2Window;
 
     fn set_at(
-        _: Me<Self>, 
         CaptureCursor(enabled): 
         CaptureCursor, _window: &mut Sdl2Window
     ) {
@@ -218,7 +217,6 @@ impl SetAt for (ShouldClose, Sdl2Window) {
     type Object = Sdl2Window;
 
     fn set_at(
-        _: Me<Self>, 
         ShouldClose(val): ShouldClose, 
         window: &mut Sdl2Window
     ) {
@@ -230,7 +228,7 @@ impl GetFrom for (DrawSize, Sdl2Window) {
     type Property = DrawSize;
     type Object = Sdl2Window;
 
-    fn get_from(_: Me<Self>, obj: &Sdl2Window) -> DrawSize {
+    fn get_from(obj: &Sdl2Window) -> DrawSize {
         let (w, h) = obj.window.get_drawable_size();
         DrawSize([w as u32, h as u32])
     }
@@ -240,7 +238,7 @@ impl GetFrom for (Title, Sdl2Window) {
     type Property = Title;
     type Object = Sdl2Window;
 
-    fn get_from(_: Me<Self>, obj: &Sdl2Window) -> Title {
+    fn get_from(obj: &Sdl2Window) -> Title {
         Title(obj.window.get_title())
     }
 }
@@ -249,7 +247,7 @@ impl SetAt for (Title, Sdl2Window) {
     type Property = Title;
     type Object = Sdl2Window;
 
-    fn set_at(_: Me<Self>, Title(val): Title, window: &mut Sdl2Window) {
+    fn set_at(Title(val): Title, window: &mut Sdl2Window) {
         window.window.set_title(val.as_slice());
     }
 }
@@ -258,7 +256,7 @@ impl GetFrom for (ExitOnEsc, Sdl2Window) {
     type Property = ExitOnEsc;
     type Object = Sdl2Window;
 
-    fn get_from(_: Me<Self>, obj: &Sdl2Window) -> ExitOnEsc {
+    fn get_from(obj: &Sdl2Window) -> ExitOnEsc {
         ExitOnEsc(obj.exit_on_esc)
     }
 }
@@ -268,7 +266,6 @@ impl SetAt for (ExitOnEsc, Sdl2Window) {
     type Object = Sdl2Window;
 
     fn set_at(
-        _: Me<Self>, 
         ExitOnEsc(val): ExitOnEsc, 
         window: &mut Sdl2Window
     ) {


### PR DESCRIPTION
Was `Me` usage necessary? Or it's not required now due to Rust changes? Crate `quack` is a bit too magical to me.

Waiting for Travis.