### PR TITLE
Explicitly use 32bit color

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,13 @@ impl Sdl2Window {
     /// Creates a new game window for SDL2.
     pub fn new(opengl: OpenGL, settings: WindowSettings) -> Sdl2Window {
         let sdl_context = sdl2::init(sdl2::INIT_EVERYTHING).unwrap();
+        
+        // Not all drivers default to 32bit color, so explicitly set it to 32bit color
+        sdl2::video::gl_set_attribute(sdl2::video::GLAttr::GLRedSize, 8);
+        sdl2::video::gl_set_attribute(sdl2::video::GLAttr::GLGreenSize, 8);
+        sdl2::video::gl_set_attribute(sdl2::video::GLAttr::GLBlueSize, 8);
+        sdl2::video::gl_set_attribute(sdl2::video::GLAttr::GLAlphaSize, 8);
+        
         let (major, minor) = opengl.get_major_minor();
         sdl2::video::gl_set_attribute(
             sdl2::video::GLAttr::GLContextMajorVersion, 


### PR DESCRIPTION
This makes it run properly under Weston for me, without this, it looks like a garbled mess.