### PR TITLE
Make anti-aliasing best-effort rather than panicking.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,7 +81,32 @@ impl Sdl2Window {
             settings.size[0] as i32,
             settings.size[1] as i32,
             sdl2::video::OPENGL| sdl2::video::RESIZABLE
-        ).unwrap();
+        );
+        let window = match window {
+            Ok(w) => w,
+            Err(_) =>
+                if settings.samples != 0 {
+                    // Retry without requiring anti-aliasing.
+                    sdl2::video::gl_set_attribute(
+                        sdl2::video::GLAttr::GLMultiSampleBuffers,
+                        0
+                            );
+                    sdl2::video::gl_set_attribute(
+                        sdl2::video::GLAttr::GLMultiSampleSamples,
+                        0
+                            );
+                    sdl2::video::Window::new(
+                        &settings.title,
+                        sdl2::video::WindowPos::PosCentered,
+                        sdl2::video::WindowPos::PosCentered,
+                        settings.size[0] as i32,
+                        settings.size[1] as i32,
+                        sdl2::video::OPENGL| sdl2::video::RESIZABLE
+                            ).unwrap()
+                } else {
+                    window.unwrap() // Panic.
+                }
+        };
         if settings.fullscreen {
             window.set_fullscreen(sdl2::video::FullscreenType::FTTrue);
         }


### PR DESCRIPTION
Here's an example of the panic it fixes:
aij@yhu:~/git/piston-examples/deform$ RUST_BACKTRACE=1 cargo run
   Compiling piston-examples-deform v0.0.1 (file:///home/aij/git/piston-examples/deform)
     Running `target/debug/piston-examples-deform`
Click in the red square and drag.
Toggle grid with G.
Reset grid with R.
thread '<main>' panicked at 'called `Result::unwrap()` on an `Err` value: "Couldn\'t find matching GLX visual"', /home/aij/git/rust/src/libcore/result.rs:775
stack backtrace:
   1:     0x7f9a2618ee59 - sys::backtrace::write::hb00e07d997b04265HyD
   2:     0x7f9a261929e2 - panicking::on_panic::he2ac5bb2c4c90392ZOJ
   3:     0x7f9a26187853 - rt::unwind::begin_unwind_inner::hcc5be3c2c3b2436bGuJ
   4:     0x7f9a26187c11 - rt::unwind::begin_unwind_fmt::h2ce25b5d5abb3f6chtJ
   5:     0x7f9a26192427 - rust_begin_unwind
   6:     0x7f9a261c3904 - panicking::panic_fmt::hb16892aee821a66fH0A
   7:     0x7f9a2608c6cc - result::Result<T, E>::unwrap::h289021542769723922
                        at /home/aij/git/rust/src/libcore/macros.rs:27
   8:     0x7f9a2608b1c9 - Sdl2Window::new::hee2cbff16eba6f8eYaa
                        at /home/aij/.cargo/git/checkouts/sdl2_window-99fd7f1ca94d6f5b/master/src/lib.rs:77
   9:     0x7f9a260480b2 - main::hc0771fbefb648e99vaa
                        at src/main.rs:25
  10:     0x7f9a2619be18 - rust_try_inner
  11:     0x7f9a2619be05 - rust_try
  12:     0x7f9a2619447a - rt::lang_start::h66c15121e827c945sJJ
  13:     0x7f9a26048af4 - main
  14:     0x7f9a252cab44 - __libc_start_main
  15:     0x7f9a26047d98 - <unknown>
  16:                0x0 - <unknown>
An unknown error occurred

To learn more, run the command again with --verbose.