### PR TITLE
Matching new SDL2 api

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "pistoncore-sdl2_window"
-version = "0.0.9"
+version = "0.0.10"
 authors = [
     "bvssvni <bvssvni@gmail.com>",
     "Coeuvre <coeuvre@gmail.com>",
@@ -26,7 +26,7 @@ name = "sdl2_window"
 
 [dependencies.sdl2]
 git = "https://github.com/AngryLawyer/rust-sdl2"
-#version = "0.1.0"
+#version = "0.2.0"
 
 [dependencies.piston]
 git = "https://github.com/pistondevelopers/piston"


### PR DESCRIPTION
SDL2's API has changed subtely to increase safety with the Window.

This has the unfortunate side-effect of making the `get_size` calls require a mut borrow, which doesn't work with Piston's window. As a way around this, whenever the window size is changed, or the title is changed, we stash the number instead.

We're only updating the window size on Resize, when we pump events. I'm not sure if this is ideal, so this is open to suggestions.

In addition, I'm not sure if we should be updating the values on going fullscreen and the like. Comments appreciated!