### PR TITLE
Updated to use SDL2 0.3, with builder-pattern for windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "pistoncore-sdl2_window"
-version = "0.0.13"
+version = "0.0.14"
 authors = [
     "bvssvni <bvssvni@gmail.com>",
     "Coeuvre <coeuvre@gmail.com>",
@@ -12,7 +12,8 @@ authors = [
     "Apointos",
     "ccgn",
     "reem",
-    "TyOverby <ty@pre-alpha.com>"]
+    "TyOverby <ty@pre-alpha.com>",
+    "Tony Aldridge <tony@angry-lawyer.com>"]
 keywords = ["sdl2", "window", "piston"]
 description = "A SDL2 back-end for the Piston game engine"
 license = "MIT"
@@ -26,7 +27,7 @@ name = "sdl2_window"
 
 [dependencies.sdl2]
 git = "https://github.com/AngryLawyer/rust-sdl2"
-#version = "0.2.0"
+#version = "0.3.0"
 
 [dependencies.piston]
 git = "https://github.com/pistondevelopers/piston"
@@ -41,4 +42,4 @@ git = "https://github.com/bjz/gl-rs"
 #version = "0.0.12"
 
 [dependencies]
-num = "0.1.21"
+num = "0.1.24"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@ pub struct Sdl2Window {
 impl Sdl2Window {
     /// Creates a new game window for SDL2.
     pub fn new(opengl: OpenGL, settings: WindowSettings) -> Sdl2Window {
-        let sdl_context = sdl2::init(sdl2::INIT_EVERYTHING).unwrap();
+        let sdl_context = sdl2::init().everything().unwrap();
 
         // Not all drivers default to 32bit color, so explicitly set it to 32bit color.
         sdl2::video::gl_set_attribute(sdl2::video::GLAttr::GLRedSize, 8);
@@ -78,21 +78,20 @@ impl Sdl2Window {
             );
         }
 
-        let window_flags = if settings.get_fullscreen() {
-            sdl2::video::OPENGL | sdl2::video::RESIZABLE | sdl2::video::FULLSCREEN
+        let mut window_builder = sdl_context.window(&settings.get_title(), settings.get_size().width as u32, settings.get_size().height as u32);
+
+        let window_builder = window_builder.position_centered()
+            .opengl()
+            .resizable();
+
+        let window_builder = if settings.get_fullscreen() {
+            window_builder.fullscreen()
         } else {
-            sdl2::video::OPENGL | sdl2::video::RESIZABLE
+            window_builder
         };
 
-        let window = sdl2::video::Window::new(
-            &sdl_context,
-            &settings.get_title(),
-            sdl2::video::WindowPos::PosCentered,
-            sdl2::video::WindowPos::PosCentered,
-            settings.get_size().width as i32,
-            settings.get_size().height as i32,
-            window_flags
-        );
+        let window = window_builder.build();
+
         let window = match window {
             Ok(w) => w,
             Err(_) =>
@@ -106,15 +105,7 @@ impl Sdl2Window {
                         sdl2::video::GLAttr::GLMultiSampleSamples,
                         0
                             );
-                    sdl2::video::Window::new(
-                        &sdl_context,
-                        &settings.get_title(),
-                        sdl2::video::WindowPos::PosCentered,
-                        sdl2::video::WindowPos::PosCentered,
-                        settings.get_size().width as i32,
-                        settings.get_size().height as i32,
-                        window_flags
-                            ).unwrap()
+                    window_builder.build().unwrap()
                 } else {
                     window.unwrap() // Panic.
                 }


### PR DESCRIPTION
Lots of parts of SDL2 now use the Builder pattern, for a slightly more pleasant interface. This updates sdl2_window to use it.