### PR TITLE
Use crates.io dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,16 +30,16 @@ git = "https://github.com/AngryLawyer/rust-sdl2"
 #version = "0.3.0"
 
 [dependencies.piston]
-git = "https://github.com/pistondevelopers/piston"
-#version = "0.1.0"
+#git = "https://github.com/pistondevelopers/piston"
+version = "0.1.2"
 
 [dependencies.shader_version]
 git = "https://github.com/pistondevelopers/shader_version"
-#version = "0.0.6"
+version = "0.0.6"
 
 [dependencies.gl]
 git = "https://github.com/bjz/gl-rs"
-#version = "0.0.12"
+version = "0.0.12"
 
 [dependencies]
 num = "0.1.24"


### PR DESCRIPTION
See https://github.com/PistonDevelopers/piston/issues/891

rust-sdl2 needs update, so can’t publish yet