### PR TITLE
Use `OpenGL::_3_2` as default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "pistoncore-sdl2_window"
-version = "0.1.0"
+version = "0.2.0"
 authors = [
     "bvssvni <bvssvni@gmail.com>",
     "Coeuvre <coeuvre@gmail.com>",
@@ -28,6 +28,6 @@ name = "sdl2_window"
 [dependencies]
 num = "0.1.24"
 sdl2 = "0.4"
-piston = "0.1.4"
+piston = "0.1.5"
 shader_version = "0.1.0"
 gl = "0.0.12"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,10 +41,11 @@ pub struct Sdl2Window {
 
 impl Sdl2Window {
     /// Creates a new game window for SDL2.
-    pub fn new(opengl: OpenGL, settings: WindowSettings) -> Self {
+    pub fn new(settings: WindowSettings) -> Self {
         use sdl2::video::{ GLProfile, gl_attr };
 
         let sdl_context = sdl2::init().everything().unwrap();
+        let opengl = settings.get_maybe_opengl().unwrap_or(OpenGL::_3_2);
         let (major, minor) = opengl.get_major_minor();
 
         // Not all drivers default to 32bit color, so explicitly set it to 32bit color.
@@ -200,6 +201,12 @@ impl Sdl2Window {
             _ => {}
         }
         None
+    }
+}
+
+impl From<WindowSettings> for Sdl2Window {
+    fn from(settings: WindowSettings) -> Sdl2Window {
+        Sdl2Window::new(settings)
     }
 }
 


### PR DESCRIPTION
This is a breaking change.

See https://github.com/PistonDevelopers/window/issues/68