### PR TITLE
Update to support subsystems in upcoming rust-sdl2 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ name = "sdl2_window"
 
 [dependencies]
 num = "0.1.25"
-sdl2 = "0.6"
+sdl2 = "0.7"
 pistoncore-window = "0.4.0"
 pistoncore-input = "0.3.0"
 shader_version = "0.2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,14 +113,17 @@ impl Sdl2Window {
 
         let window = match window {
             Ok(w) => w,
-            Err(_) =>
+            Err(e) =>
                 if settings.get_samples() != 0 {
                     // Retry without requiring anti-aliasing.
                     gl_attr.set_multisample_buffers(0);
                     gl_attr.set_multisample_samples(0);
-                    window_builder.build().unwrap()
+                    match window_builder.build() {
+                        Ok(w) => w,
+                        Err(e) => return Err(e)
+                    }
                 } else {
-                    window.unwrap() // Panic.
+                    return Err(e);
                 }
         };
 
@@ -128,7 +131,7 @@ impl Sdl2Window {
         let text_input_util = video.text_input();
         text_input_util.start();
 
-        let context = window.gl_create_context().unwrap();
+        let context = try!(window.gl_create_context());
 
         // Load the OpenGL function pointers.
         gl::load_with(|a| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,9 +131,8 @@ impl Sdl2Window {
         let context = window.gl_create_context().unwrap();
 
         // Load the OpenGL function pointers.
-        let video_subsystem_clone = video.clone();
-        gl::load_with(move |a| {
-            video_subsystem_clone.gl_get_proc_address(a)
+        gl::load_with(|a| {
+            video.gl_get_proc_address(a)
         });
 
         if settings.get_vsync() {


### PR DESCRIPTION
The subsystems changes were just merged into `rust-sdl2` which dramatically overhaul the SDL initialization process and allow passing around of reference-counted clones of subsystem handles. AngryLawyer/rust-sdl2#441 and AngryLawyer/rust-sdl2#443

This PR updates `Sdl2Window` and its trait implementations to use them instead of initializing SDL itself. The existing `Sdl2Window::new` function will behave just the same as before, and a new `Sdl2Window::new_with_subsystems` has been added to allow calling code to initialize SDL and get subsystems on its own. This makes it, for example, easier to initialize the audio subsystem and control that alongside the window.

Breaking API change for this is that the two Sdl2Window creation functions both return `Result<Sdl2Window, String>` instead, allowing them to fail gracefully instead of `panic`.

Overall this should improve reusability.