### PR TITLE
Use Result return types in Sdl2Window constructors.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,14 +44,14 @@ pub struct Sdl2Window {
 impl Sdl2Window {
     /// Creates a new game window for SDL2. This will initialize SDL and the video subsystem.
     /// You can retrieve both via the public fields on the `Sdl2Window` struct.
-    pub fn new(settings: WindowSettings) -> Self {
-        let sdl = sdl2::init().unwrap();
-        let video_subsystem = sdl.video().unwrap();
+    pub fn new(settings: WindowSettings) -> Result<Self, String> {
+        let sdl = try!(sdl2::init());
+        let video_subsystem = try!(sdl.video());
         Self::with_subsystem(video_subsystem, settings)
     }
 
     /// Creates a window with the supplied SDL Video subsystem.
-    pub fn with_subsystem(video_subsystem: sdl2::VideoSubsystem, settings: WindowSettings) -> Self {
+    pub fn with_subsystem(video_subsystem: sdl2::VideoSubsystem, settings: WindowSettings) -> Result<Self, String> {
         use sdl2::video::GLProfile;
 
         let sdl_context = video_subsystem.sdl();
@@ -106,16 +106,16 @@ impl Sdl2Window {
                     let gl_attr = video_subsystem.gl_attr();
                     gl_attr.set_multisample_buffers(0);
                     gl_attr.set_multisample_samples(0);
-                    window_builder.build().unwrap()
+                    try!(window_builder.build())
                 } else {
-                    window.unwrap() // Panic.
+                    try!(window)
                 }
         };
 
         // Send text input events.
         video_subsystem.text_input().start();
 
-        let context = window.gl_create_context().unwrap();
+        let context = try!(window.gl_create_context());
 
         // Load the OpenGL function pointers.
         gl::load_with(|name| video_subsystem.gl_get_proc_address(name));
@@ -139,7 +139,7 @@ impl Sdl2Window {
             draw_size: settings.get_size(),
         };
         window.update_draw_size();
-        window
+        Ok(window)
     }
 
     fn update_draw_size(&mut self) {
@@ -218,12 +218,6 @@ impl Sdl2Window {
             _ => {}
         }
         None
-    }
-}
-
-impl From<WindowSettings> for Sdl2Window {
-    fn from(settings: WindowSettings) -> Sdl2Window {
-        Sdl2Window::new(settings)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,15 +42,23 @@ pub struct Sdl2Window {
 }
 
 impl Sdl2Window {
-    /// Creates a new game window for SDL2.
+    /// Creates a new game window for SDL2. This will initialize SDL and the video subsystem.
+    /// You can retrieve both via the public fields on the `Sdl2Window` struct.
     pub fn new(settings: WindowSettings) -> Self {
+        let sdl = sdl2::init().unwrap();
+        let video_subsystem = sdl.video().unwrap();
+        Self::with_subsystem(video_subsystem, settings)
+    }
+
+    /// Creates a window with the supplied SDL Video subsystem.
+    pub fn with_subsystem(video_subsystem: sdl2::VideoSubsystem, settings: WindowSettings) -> Self {
         use sdl2::video::GLProfile;
 
-        let sdl_context = sdl2::init().unwrap();
+        let sdl_context = video_subsystem.sdl();
+
         let opengl = settings.get_maybe_opengl().unwrap_or(OpenGL::V3_2);
         let (major, minor) = opengl.get_major_minor();
 
-        let video_subsystem = sdl_context.video().unwrap();
         {
             let gl_attr = video_subsystem.gl_attr();
 


### PR DESCRIPTION
Depends on #192 

Makes `new` and `with_subsystem` return `Result<Sdl2Window, String>` instead of `Sdl2Window` so that the calling code may gracefully handle any error conditions during initialization (perhaps falling back to another window implementation). This also removes the implementation of `From<WindowSettings>` as it is not possible to implement a foreign trait on a foreign type (`Result`).

I separated out these two PRs such that one could be used in a minor non-breaking release of the crate, and this one could be released in a breaking change.