### PR TITLE
Fix Issue #225: Typo in Documentation for `Sdl2Window` Struct

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,7 @@ impl JoystickState {
     }
 }
 
-/// A widow implemented by SDL2 back-end.
+/// A window implemented by SDL2 back-end.
 pub struct Sdl2Window {
     /// SDL window handle.
     pub window: sdl2::video::Window,


### PR DESCRIPTION
Changed `widow` to `window`.