### PR TITLE
Fake capturing of cursor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "pistoncore-sdl2_window"
-version = "0.30.0"
+version = "0.30.1"
 authors = [
     "bvssvni <bvssvni@gmail.com>",
     "Coeuvre <coeuvre@gmail.com>",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -276,6 +276,10 @@ impl Sdl2Window {
                 return Some(Input::Release(Button::Mouse(sdl2_map_mouse(button))));
             }
             Event::MouseMotion { x, y, xrel: dx, yrel: dy, .. } => {
+                if self.is_capturing_cursor {
+                    // Skip normal mouse movement and emit relative motion only.
+                    return Some(Input::Move(Motion::MouseRelative(dx as f64, dy as f64)));
+                }
                 // Send relative move movement next time.
                 self.mouse_relative = Some((dx as f64, dy as f64));
                 return Some(Input::Move(Motion::MouseCursor(x as f64, y as f64)));


### PR DESCRIPTION
See https://github.com/PistonDevelopers/piston-examples/issues/349

It is not perfect, since the cursor is only hidden and warped back to
the center of the window.

By shaking the cursor on OSX the icon appears for a moment and shrinks
(meant to show the cursor).

Otherwise, it looks good.