### PR TITLE
bump versions, specifically sdl and gl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "pistoncore-sdl2_window"
-version = "0.69.0"
+version = "0.70.0"
 authors = [
     "bvssvni <bvssvni@gmail.com>",
     "Coeuvre <coeuvre@gmail.com>",
@@ -26,8 +26,8 @@ homepage = "https://github.com/pistondevelopers/sdl2_window"
 name = "sdl2_window"
 
 [dependencies]
-sdl2 = "0.35.2"
+sdl2 = "0.37.0"
 pistoncore-window = "1.0.0"
-pistoncore-input = "1.0.0"
+pistoncore-input = "1.0.1"
 shader_version = "0.7.0"
-gl = "0.13.0"
+gl = "0.14.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -580,7 +580,12 @@ impl OpenGLWindow for Sdl2Window {
 
 /// Maps a SDL2 key to piston-input key.
 pub fn sdl2_map_key(keycode: sdl2::keyboard::Keycode) -> keyboard::Key {
-    (keycode as u32).into()
+    let keycode = keycode.into_i32();
+    use std::convert::TryInto;
+    let keycode: u32 = keycode
+        .try_into()
+        .expect("sdl keycode purely uses positive numbers");
+    keycode.into()
 }
 
 /// Maps a SDL2 mouse button to piston-input button.


### PR DESCRIPTION
had to fix conversion logic for keypresses.

this is mainly so i can bump the versions of opengl_graphics.

i noticed that this crate is on a very old rust edition and has not been seen by rustfmt lately, is that something the maintainers are interested in changing? then i could make another pr or 2.